### PR TITLE
Add _generate_seeded_urls ftn and test, consolidate test data.

### DIFF
--- a/jailscraper/spiders/inmate_spider.py
+++ b/jailscraper/spiders/inmate_spider.py
@@ -64,7 +64,7 @@ class InmatesSpider(scrapy.Spider):
         f = self._get_seed_file()
         data = list(csv.DictReader(f))
 
-        urls = _generate_seeded_urls(data)
+        urls = self._generate_seeded_urls(data)
         dates = [datetime.strptime(row['Booking_Date'], '%Y-%m-%d') for row in data]
 
         last_date = max(dates) + ONE_DAY

--- a/jailscraper/spiders/inmate_spider.py
+++ b/jailscraper/spiders/inmate_spider.py
@@ -64,7 +64,7 @@ class InmatesSpider(scrapy.Spider):
         f = self._get_seed_file()
         data = list(csv.DictReader(f))
 
-        urls = [app_config.INMATE_URL_TEMPLATE.format(row['Booking_Id']) for row in data]
+        urls = _generate_seeded_urls(data)
         dates = [datetime.strptime(row['Booking_Date'], '%Y-%m-%d') for row in data]
 
         last_date = max(dates) + ONE_DAY
@@ -110,6 +110,10 @@ class InmatesSpider(scrapy.Spider):
         f = open(last_file)
         self.log('Used {0} from local file system to seed scrape.'.format(last_file))
         return f
+
+    def _generate_seeded_urls(self, data):
+        """Use seeded data to generate known URLs."""
+        return [app_config.INMATE_URL_TEMPLATE.format(row['Booking_Id']) for row in data]
 
     def _save_local(self, response, inmate):
         """Save scraped page to local filesystem."""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,62 @@
+
+
+TEST_INMATES_CSV = [
+    {
+        'Age_At_Booking': 21,
+        'Bail_Amount': '50,000.00',
+        'Booking_Id': '2015-0904292',
+        'Charges': """720 ILCS 5/11-9(a)(2)
+PUBLIC INDECENCY/LEWD EXPOSURE""",
+        'Court_Date': '2017-07-20',
+        'Court_Location': """Criminal Courts Building
+Criminal Courts Building
+
+,""",
+        'Gender': 'Male',
+        'Height': '509',
+        'Housing_Location': 'DIV9-3B-3105-1',
+        'Inmate_Hash': '7b7d440062f7cf7b3bc15a6c0fd543f4d84fd2e74d05969401085ce5c8d3e03b',
+        'Race': 'BK',
+        'Weight': '160',
+    },
+    # Just a random inmate
+    {
+        'Age_At_Booking': 21,
+        'Bail_Amount': '50,000.00',
+        'Booking_Id': '2017-0608010',
+        'Charges': """720 ILCS 5/24-1.6(a)(3)(a)(5)
+AGG UUW/LOADED PISTOL, REVOLVER, HANDGUN-NO CCL""",
+        'Court_Date': '2017-06-28',
+        'Court_Location': """Markham
+Markham
+
+,""",
+        'Gender': 'Male',
+        'Height': '507',
+        'Housing_Location': 'DIV2-D1-D-32',
+        'Inmate_Hash': 'af4da0bc3ecf5fe9568b902fbcec6588282c7c3b5377cfba94a44e3ce0ea3978',
+        'Race': 'BK',
+        'Weight': '165',
+    },
+    {
+        'Age_At_Booking': 27,
+        'Bail_Amount': '*NO BOND*',
+        'Booking_Id': '2017-0612061',
+        'Charges': '',
+        'Court_Date': '',
+        'Court_Location': '',
+        'Gender': 'Male',
+        'Height': '510',
+        'Housing_Location': '',
+        'Inmate_Hash': 'ec407ab41d1d1fc319113516ce4f871a59a0b6f4c52a283507bf463d3fc55fdd',
+        'Race': 'BK',
+        'Weight': '185',
+    },
+]
+
+
+def to_lower(inmate):
+    return dict([(k.lower(), v) for k, v in inmate.items()])
+
+
+TEST_INMATES = map(to_lower, TEST_INMATES_CSV)

--- a/tests/test_inmate_spider.py
+++ b/tests/test_inmate_spider.py
@@ -1,0 +1,16 @@
+
+import jailscraper.spiders.inmate_spider as inmate_spider
+from tests import TEST_INMATES_CSV
+
+
+EXPECTED = [
+    'http://www2.cookcountysheriff.org/search2/details.asp?jailnumber=2015-0904292',  # NOQA: E501
+    'http://www2.cookcountysheriff.org/search2/details.asp?jailnumber=2017-0608010',  # NOQA: E501
+    'http://www2.cookcountysheriff.org/search2/details.asp?jailnumber=2017-0612061',  # NOQA: E501
+]
+
+
+def test_generate_seeded_urls():
+    spider = inmate_spider.InmatesSpider()
+    urls = spider._generate_seeded_urls(TEST_INMATES_CSV)
+    assert EXPECTED == urls

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 import pytest
 
 from jailscraper.models import InmatePage
+from tests import TEST_INMATES
 
 
 def get_inmate(id):
@@ -8,61 +9,16 @@ def get_inmate(id):
         body = f.read()
     return InmatePage(body)
 
-# @TODO is there a way to do this more elegantly with fixtures?
-testdata = (
-    # An old inmate: Especially important is to make sure hash is correct
-    (get_inmate('2015-0904292'), {
-        'age_at_booking': 21,
-        'bail_amount': '50,000.00',
-        'booking_id': '2015-0904292',
-        'charges': """720 ILCS 5/11-9(a)(2)
-PUBLIC INDECENCY/LEWD EXPOSURE""",
-        'court_date': '2017-07-20',
-        'court_location': """Criminal Courts Building
-Criminal Courts Building
 
-,""",
-        'gender': 'Male',
-        'height': '509',
-        'housing_location': 'DIV9-3B-3105-1',
-        'inmate_hash': '7b7d440062f7cf7b3bc15a6c0fd543f4d84fd2e74d05969401085ce5c8d3e03b',
-        'race': 'BK',
-        'weight': '160',
-    }),
-    # Just a random inmate
-    (get_inmate('2017-0608010'), {
-        'age_at_booking': 21,
-        'bail_amount': '50,000.00',
-        'booking_id': '2017-0608010',
-        'charges': """720 ILCS 5/24-1.6(a)(3)(a)(5)
-AGG UUW/LOADED PISTOL, REVOLVER, HANDGUN-NO CCL""",
-        'court_date': '2017-06-28',
-        'court_location': """Markham
-Markham
-
-,""",
-        'gender': 'Male',
-        'height': '507',
-        'housing_location': 'DIV2-D1-D-32',
-        'inmate_hash': 'af4da0bc3ecf5fe9568b902fbcec6588282c7c3b5377cfba94a44e3ce0ea3978',
-        'race': 'BK',
-        'weight': '165',
-    }),
-    (get_inmate('2017-0612061'), {
-        'age_at_booking': 27,
-        'bail_amount': '*NO BOND*',
-        'booking_id': '2017-0612061',
-        'charges': '',
-        'court_date': '',
-        'court_location': '',
-        'gender': 'Male',
-        'height': '510',
-        'housing_location': '',
-        'inmate_hash': 'ec407ab41d1d1fc319113516ce4f871a59a0b6f4c52a283507bf463d3fc55fdd',
-        'race': 'BK',
-        'weight': '185',
-    }),
+expected = (
+    get_inmate('2015-0904292'),
+    get_inmate('2017-0608010'),
+    get_inmate('2017-0612061'),
 )
+
+
+# @TODO is there a way to do this more elegantly with fixtures?
+testdata = list(zip(expected, TEST_INMATES))
 
 
 @pytest.mark.parametrize("inmate,expected", testdata)


### PR DESCRIPTION
Trivial test to cement url generation from known/seeded data, including moving shared test data to its own space.

Closes #70.

The lower-casing of data is maybe a little cutesy :) , happy to back that out and leave 2x data if we prefer.